### PR TITLE
Fix: COT initial in debug mode

### DIFF
--- a/methods/cot/cot_main.py
+++ b/methods/cot/cot_main.py
@@ -1,8 +1,8 @@
 from methods.mas_base import MAS
 
 class CoT(MAS):
-    def __init__(self, general_config):
-        super().__init__(general_config)
+    def __init__(self, general_config, method_config_name=None):
+        super().__init__(general_config, method_config_name=method_config_name)
     
     def inference(self, sample):
         


### PR DESCRIPTION
## 🛠 Bug Fix: Compatibility Issue with `method_config_name` in `inference.py`

### 🐞 Problem
In the original `inference.py`, the `MAS_METHOD` is initialized using the following pattern:

```python
mas = MAS_METHOD(general_config, method_config_name=args.method_config_name)

However, some method implementations, such as CoT, do not accept method_config_name as a constructor argument. This causes a TypeError when attempting to run inference with those methods.